### PR TITLE
chore(ci): update workflows to organization-tools@v1.1.4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   deploy:
     name: Deploy to Production
-    uses: ArkeonProject/organization-tools/.github/workflows/cd-node-vercel.yml@v1.0.1
+    uses: ArkeonProject/organization-tools/.github/workflows/cd-node-vercel.yml@v1.1.4
     with:
       node-version: '20'
       package-manager: 'pnpm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   ci:
     name: Continuous Integration
-    uses: ArkeonProject/organization-tools/.github/workflows/ci-node.yml@v1.0.1
+    uses: ArkeonProject/organization-tools/.github/workflows/ci-node.yml@v1.1.4
     with:
       node-version: '20'
       package-manager: 'pnpm'

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   create-hotfix:
     name: Create Hotfix
-    uses: ArkeonProject/organization-tools/.github/workflows/hotfix-create.yml@v1.0.1
+    uses: ArkeonProject/organization-tools/.github/workflows/hotfix-create.yml@v1.1.4
     with:
       description: ${{ github.event.inputs.description }}
       issue-number: ${{ github.event.inputs.issue-number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   prepare-release:
     name: Prepare Release
     if: github.event_name == 'workflow_dispatch'
-    uses: ArkeonProject/organization-tools/.github/workflows/release-prepare.yml@v1.0.1
+    uses: ArkeonProject/organization-tools/.github/workflows/release-prepare.yml@v1.1.4
     with:
       version-bump: ${{ github.event.inputs.version-bump }}
       project-type: 'node'
@@ -30,7 +30,7 @@ jobs:
   publish-release:
     name: Publish Release
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    uses: ArkeonProject/organization-tools/.github/workflows/release-publish.yml@v1.0.1
+    uses: ArkeonProject/organization-tools/.github/workflows/release-publish.yml@v1.1.4
     with:
       project-type: 'node'
       create-github-release: true


### PR DESCRIPTION
Updates all workflows (CD, CI, Release, Hotfix) to use version v1.1.4 of the reusable workflows from ArkeonProject/organization-tools. This includes recent fixes for release management and CD secrets handling.