### PR TITLE
fix: meta tag Impact.com en root.tsx (SSR)

### DIFF
--- a/src/root.tsx
+++ b/src/root.tsx
@@ -50,7 +50,10 @@ export function Layout({ children }: { children: React.ReactNode }) {
 
         {/* AdSense */}
         <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4754704679096236" crossOrigin="anonymous"></script>
-        
+
+        {/* Impact.com verification */}
+        <meta name="impact-site-verification" content="4523a10c-aa16-4890-8092-0571f75c46f6" />
+
       </head>
       <body>
         <noscript>


### PR DESCRIPTION
## Summary

- El meta tag de verificación de Impact.com estaba en `index.html` que no se sirve en producción (el proyecto usa SSR con React Router)
- Movido a `src/root.tsx` donde se genera el `<head>` real del SSR
- Cambiado `value` por `content` para que sea TypeScript-compatible

## Test plan

- [ ] Verificar que `<meta name="impact-site-verification" content="4523a10c-aa16-4890-8092-0571f75c46f6">` aparece en el código fuente de `arkeonixlabs.com`
- [ ] Completar verificación en Impact.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)