### PR TITLE
feat(recursos): gestión de afiliados desde /admin

### DIFF
--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -5,9 +5,10 @@ import RichTextEditor from "@/components/admin/RichTextEditor";
 import {
   FiUsers, FiFileText, FiMail, FiLock, FiBarChart2,
   FiPlus, FiEdit2, FiTrash2,
-  FiCheck, FiX, FiLayout,
+  FiCheck, FiX, FiLayout, FiLink,
 } from "react-icons/fi";
 import type { PostListItem } from "@/types/post";
+import type { AffiliateTool, AffiliateToolInsert } from "@/types/affiliate";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -30,7 +31,7 @@ interface AdminPost {
   difficulty?: string | null;
 }
 
-type Tab = "dashboard" | "posts" | "lab";
+type Tab = "dashboard" | "posts" | "lab" | "affiliates";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -625,12 +626,252 @@ function PostsManager({ table }: { table: TableName }) {
   );
 }
 
+// ─── Affiliates Manager ───────────────────────────────────────────────────────
+
+const AFFILIATE_CATEGORIES = ["learning", "testing", "hosting", "databases", "devtools"];
+
+const EMPTY_TOOL: AffiliateToolInsert = {
+  name: "",
+  platform: "",
+  category: "learning",
+  description_es: "",
+  description_en: "",
+  url: "",
+  accent_color: "#00aaff",
+  active: true,
+  sort_order: 0,
+};
+
+function AffiliatesManager() {
+  const [tools, setTools] = useState<AffiliateTool[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [editing, setEditing] = useState<AffiliateTool | "new" | null>(null);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [form, setForm] = useState<AffiliateToolInsert>({ ...EMPTY_TOOL });
+  const [saving, setSaving] = useState(false);
+  const [formErr, setFormErr] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from("affiliate_tools")
+      .select("*")
+      .order("sort_order", { ascending: true })
+      .order("id", { ascending: true });
+    if (error) { setErr(error.message); } else { setTools((data as AffiliateTool[]) ?? []); }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const openNew = () => { setForm({ ...EMPTY_TOOL }); setFormErr(null); setEditing("new"); };
+  const openEdit = (tool: AffiliateTool) => {
+    setForm({
+      name: tool.name, platform: tool.platform, category: tool.category,
+      description_es: tool.description_es, description_en: tool.description_en,
+      url: tool.url, accent_color: tool.accent_color,
+      active: tool.active, sort_order: tool.sort_order,
+    });
+    setFormErr(null);
+    setEditing(tool);
+  };
+
+  const handleSave = async () => {
+    if (!form.name.trim() || !form.url.trim() || !form.platform.trim()) {
+      setFormErr("Name, platform and URL are required.");
+      return;
+    }
+    setSaving(true);
+    setFormErr(null);
+    const { error } = editing === "new"
+      ? await supabase.from("affiliate_tools").insert(form)
+      : await supabase.from("affiliate_tools").update(form).eq("id", (editing as AffiliateTool).id);
+    if (error) { setFormErr(error.message); }
+    else { setEditing(null); void load(); }
+    setSaving(false);
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!confirm("¿Eliminar esta herramienta?")) return;
+    setDeletingId(id);
+    const { error } = await supabase.from("affiliate_tools").delete().eq("id", id);
+    if (error) { alert(error.message); }
+    else { setTools((prev) => prev.filter((t) => t.id !== id)); }
+    setDeletingId(null);
+  };
+
+  const handleToggleActive = async (tool: AffiliateTool) => {
+    const { error } = await supabase.from("affiliate_tools").update({ active: !tool.active }).eq("id", tool.id);
+    if (!error) setTools((prev) => prev.map((t) => t.id === tool.id ? { ...t, active: !t.active } : t));
+  };
+
+  const inputClass = "w-full px-3 py-2.5 rounded-xl bg-muted border border-border focus:ring-2 focus:ring-primary/40 focus:border-primary/60 outline-none transition-all text-sm";
+  const labelClass = "block text-xs font-medium text-muted-foreground mb-1.5";
+  const set = (k: keyof AffiliateToolInsert, v: unknown) => setForm((f) => ({ ...f, [k]: v }));
+
+  if (editing !== null) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-display font-bold">
+            {editing === "new" ? "Nueva herramienta" : "Editar herramienta"}
+          </h2>
+          <div className="flex gap-2">
+            <button onClick={() => setEditing(null)} className="flex items-center gap-1.5 px-4 py-2 rounded-xl border border-border text-sm hover:bg-muted transition-all">
+              <FiX className="text-xs" /> Cancelar
+            </button>
+            <button
+              onClick={() => { void handleSave(); }}
+              disabled={saving}
+              className="flex items-center gap-1.5 px-5 py-2 rounded-xl bg-primary text-primary-foreground font-semibold text-sm hover:opacity-90 disabled:opacity-50 transition-all"
+            >
+              <FiCheck className="text-xs" />
+              {saving ? "Guardando…" : editing === "new" ? "Crear" : "Actualizar"}
+            </button>
+          </div>
+        </div>
+
+        {formErr && <p className="text-red-400 text-sm px-4 py-3 rounded-xl bg-red-400/10 border border-red-400/20">{formErr}</p>}
+
+        <div className="glass-card rounded-2xl p-5 space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className={labelClass}>Nombre *</label>
+              <input className={inputClass} value={form.name} onChange={(e) => set("name", e.target.value)} placeholder="Curso Playwright con Artem Bondar" />
+            </div>
+            <div>
+              <label className={labelClass}>Plataforma *</label>
+              <input className={inputClass} value={form.platform} onChange={(e) => set("platform", e.target.value)} placeholder="Udemy" />
+            </div>
+            <div>
+              <label className={labelClass}>Categoría</label>
+              <select className={inputClass} value={form.category} onChange={(e) => set("category", e.target.value)}>
+                {AFFILIATE_CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className={labelClass}>Color de acento</label>
+              <div className="flex gap-2 items-center">
+                <input type="color" value={form.accent_color} onChange={(e) => set("accent_color", e.target.value)} className="w-10 h-10 rounded-lg border border-border cursor-pointer bg-muted" />
+                <input className={`${inputClass} flex-1`} value={form.accent_color} onChange={(e) => set("accent_color", e.target.value)} placeholder="#A435F0" />
+              </div>
+            </div>
+            <div className="md:col-span-2">
+              <label className={labelClass}>URL de afiliado *</label>
+              <input className={inputClass} value={form.url} onChange={(e) => set("url", e.target.value)} placeholder="https://www.udemy.com/course/...?ref=XXX" />
+            </div>
+            <div>
+              <label className={labelClass}>Orden</label>
+              <input type="number" className={inputClass} value={form.sort_order} onChange={(e) => set("sort_order", parseInt(e.target.value) || 0)} />
+            </div>
+            <div className="flex items-center gap-3 pt-5">
+              <input type="checkbox" id="active" checked={form.active} onChange={(e) => set("active", e.target.checked)} className="w-4 h-4 rounded accent-primary cursor-pointer" />
+              <label htmlFor="active" className="text-sm cursor-pointer">Activo (visible en /recursos)</label>
+            </div>
+          </div>
+
+          <div>
+            <label className={labelClass}>Descripción en español</label>
+            <textarea rows={3} className={`${inputClass} resize-none`} value={form.description_es} onChange={(e) => set("description_es", e.target.value)} placeholder="El mejor curso de Playwright para QA automation…" />
+          </div>
+          <div>
+            <label className={labelClass}>Descripción en inglés</label>
+            <textarea rows={3} className={`${inputClass} resize-none`} value={form.description_en} onChange={(e) => set("description_en", e.target.value)} placeholder="The best Playwright course for QA automation…" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">{tools.length} herramientas</span>
+        <button
+          onClick={openNew}
+          className="flex items-center gap-2 px-4 py-2 rounded-xl bg-primary text-primary-foreground font-semibold text-sm hover:opacity-90 transition-all"
+        >
+          <FiPlus /> Nueva herramienta
+        </button>
+      </div>
+
+      {loading && <div className="space-y-2">{Array.from({ length: 3 }).map((_, i) => <div key={i} className="h-14 glass-card rounded-xl animate-pulse" />)}</div>}
+      {err && <p className="text-red-400 text-sm">{err}</p>}
+
+      {!loading && tools.length === 0 && (
+        <div className="glass-card rounded-2xl p-10 text-center text-muted-foreground">
+          No hay herramientas todavía. Crea la primera.
+        </div>
+      )}
+
+      {!loading && tools.length > 0 && (
+        <div className="glass-card rounded-2xl overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border/60">
+                <th className="text-left px-5 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wider">Nombre</th>
+                <th className="text-left px-3 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wider hidden md:table-cell">Plataforma</th>
+                <th className="text-left px-3 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wider hidden lg:table-cell">Categoría</th>
+                <th className="text-left px-3 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wider">Estado</th>
+                <th className="px-5 py-3" />
+              </tr>
+            </thead>
+            <tbody>
+              {tools.map((tool, i) => (
+                <tr key={tool.id} className={`border-b border-border/30 last:border-0 hover:bg-muted/40 transition-colors ${i % 2 === 0 ? "" : "bg-muted/10"}`}>
+                  <td className="px-5 py-3">
+                    <div className="flex items-center gap-2">
+                      <span className="w-3 h-3 rounded-full shrink-0" style={{ backgroundColor: tool.accent_color }} />
+                      <p className="font-medium truncate max-w-[200px]">{tool.name}</p>
+                    </div>
+                  </td>
+                  <td className="px-3 py-3 hidden md:table-cell">
+                    <span className="text-xs px-2 py-0.5 rounded-md bg-muted border border-border/60">{tool.platform}</span>
+                  </td>
+                  <td className="px-3 py-3 text-muted-foreground hidden lg:table-cell text-xs">{tool.category}</td>
+                  <td className="px-3 py-3">
+                    <button
+                      onClick={() => { void handleToggleActive(tool); }}
+                      className={`text-xs px-2.5 py-1 rounded-full font-medium transition-all ${
+                        tool.active
+                          ? "bg-green-500/15 text-green-400 hover:bg-green-500/25"
+                          : "bg-yellow-500/15 text-yellow-400 hover:bg-yellow-500/25"
+                      }`}
+                    >
+                      {tool.active ? "Activo" : "Inactivo"}
+                    </button>
+                  </td>
+                  <td className="px-5 py-3">
+                    <div className="flex items-center gap-2 justify-end">
+                      <a href={tool.url} target="_blank" rel="noopener noreferrer" className="p-1.5 rounded-lg hover:bg-primary/10 hover:text-primary transition-colors" title="Abrir link">
+                        <FiLink className="text-sm" />
+                      </a>
+                      <button onClick={() => openEdit(tool)} className="p-1.5 rounded-lg hover:bg-primary/10 hover:text-primary transition-colors" title="Editar">
+                        <FiEdit2 className="text-sm" />
+                      </button>
+                      <button onClick={() => { void handleDelete(tool.id); }} disabled={deletingId === tool.id} className="p-1.5 rounded-lg hover:bg-red-500/10 hover:text-red-400 transition-colors disabled:opacity-40" title="Eliminar">
+                        <FiTrash2 className="text-sm" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ─── Page ────────────────────────────────────────────────────────────────────
 
 const TABS: { id: Tab; label: string; icon: React.ElementType }[] = [
   { id: "dashboard", label: "Overview", icon: FiLayout },
   { id: "posts", label: "Blog Posts", icon: FiFileText },
   { id: "lab", label: "Lab Posts", icon: FiBarChart2 },
+  { id: "affiliates", label: "Afiliados", icon: FiLink },
 ];
 
 export default function AdminPage() {
@@ -694,6 +935,7 @@ export default function AdminPage() {
           {tab === "dashboard" && <Overview />}
           {tab === "posts" && <PostsManager table="posts" />}
           {tab === "lab" && <PostsManager table="lab_posts" />}
+          {tab === "affiliates" && <AffiliatesManager />}
         </div>
       )}
     </div>

--- a/src/pages/RecursosPage.tsx
+++ b/src/pages/RecursosPage.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { Helmet } from "react-helmet-async";
 import {
-  FiFilter, FiChevronDown, FiSearch, FiExternalLink,
-  FiMonitor, FiCloud, FiServer, FiDatabase, FiBookOpen, FiBell, FiZap,
+  FiFilter, FiChevronDown, FiSearch, FiExternalLink, FiBookOpen,
 } from "react-icons/fi";
 import PostList from "@/components/posts/PostList";
 import Pagination from "@/components/ui/Pagination";
@@ -33,65 +32,11 @@ interface AffiliateTool {
 
 const AFFILIATE_TOOLS: AffiliateTool[] = [
   {
-    name: "BrowserStack",
-    category: "testing",
-    descriptionEs: "Prueba tu web en 3.000+ navegadores reales y dispositivos móviles sin mantener infraestructura propia. Imprescindible para QA automation.",
-    descriptionEn: "Test your web app on 3,000+ real browsers and mobile devices without maintaining your own infra. Essential for QA automation.",
-    url: "#", // TODO: https://www.browserstack.com/affiliates
-    icon: FiMonitor,
-    accent: "#F56A00",
-  },
-  {
-    name: "DigitalOcean",
-    category: "hosting",
-    descriptionEs: "Hosting en cloud sencillo y asequible para developers. $25 de crédito gratuito para quien se registre con tu link.",
-    descriptionEn: "Simple and affordable cloud hosting for developers. $25 free credit for anyone who signs up through your link.",
-    url: "#", // TODO: https://www.digitalocean.com/referral
-    icon: FiCloud,
-    accent: "#0080FF",
-  },
-  {
-    name: "Railway",
-    category: "hosting",
-    descriptionEs: "Despliega backends, bases de datos y workers en segundos. Precio por uso, sin configuración de servidores.",
-    descriptionEn: "Deploy backends, databases and workers in seconds. Usage-based pricing, no server config.",
-    url: "#", // TODO: https://railway.app referral link from your dashboard
-    icon: FiServer,
-    accent: "#7B2FBE",
-  },
-  {
-    name: "Vercel",
-    category: "hosting",
-    descriptionEs: "La plataforma de referencia para desplegar apps Next.js con previews automáticas, CDN global y zero-config.",
-    descriptionEn: "The go-to platform for deploying Next.js apps with automatic previews, global CDN and zero-config.",
-    url: "#", // TODO: https://vercel.com/referral
-    icon: FiZap,
-    accent: "#FFFFFF",
-  },
-  {
-    name: "Supabase",
-    category: "databases",
-    descriptionEs: "PostgreSQL como servicio con auth, storage y realtime incluidos. La alternativa open source a Firebase.",
-    descriptionEn: "PostgreSQL as a service with auth, storage and realtime built in. The open source alternative to Firebase.",
-    url: "#", // TODO: https://supabase.com/partners
-    icon: FiDatabase,
-    accent: "#3ECF8E",
-  },
-  {
-    name: "Sentry",
-    category: "devtools",
-    descriptionEs: "Monitorización de errores en tiempo real con trazas completas. Detecta bugs en producción antes de que los reporten tus usuarios.",
-    descriptionEn: "Real-time error monitoring with full stack traces. Catch production bugs before your users report them.",
-    url: "#", // TODO: https://sentry.io/partners
-    icon: FiBell,
-    accent: "#F55150",
-  },
-  {
     name: "Udemy",
     category: "learning",
     descriptionEs: "Cursos de Playwright, ISTQB, Next.js y QA automation con descuentos frecuentes. Ideal para juniors que quieren aprender con proyectos reales.",
     descriptionEn: "Playwright, ISTQB, Next.js and QA automation courses with frequent discounts. Great for juniors learning with real projects.",
-    url: "#", // TODO: https://www.udemy.com/affiliate (via Impact.com)
+    url: "#", // TODO: sustituir por link de afiliado de Udemy (Impact.com)
     icon: FiBookOpen,
     accent: "#A435F0",
   },
@@ -311,7 +256,7 @@ export default function RecursosPage() {
                   <div className="flex items-start justify-between gap-3">
                     <div className="flex items-center gap-3">
                       <div
-                        className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
+                        className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
                         style={{ backgroundColor: `${tool.accent}1A`, border: `1px solid ${tool.accent}40` }}
                       >
                         <Icon className="w-5 h-5 shrink-0" style={{ color: tool.accent }} />

--- a/src/pages/RecursosPage.tsx
+++ b/src/pages/RecursosPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { Helmet } from "react-helmet-async";
 import {
-  FiFilter, FiChevronDown, FiSearch, FiExternalLink, FiBookOpen,
+  FiFilter, FiChevronDown, FiSearch, FiExternalLink,
 } from "react-icons/fi";
 import PostList from "@/components/posts/PostList";
 import Pagination from "@/components/ui/Pagination";
@@ -11,44 +11,19 @@ import Card from "@/components/ui/Card";
 import { supabase } from "@/lib/supabase";
 import { useLocale } from "@/hooks/useLocale";
 import type { PostListItem } from "@/types/post";
-import type { ElementType } from "react";
+import type { AffiliateTool } from "@/types/affiliate";
 
-// ---------------------------------------------------------------------------
-// Affiliate tools data
-// TODO: replace each `url` with your real affiliate link when approved
 // ---------------------------------------------------------------------------
 
 type AffiliateCategory = "all" | "testing" | "hosting" | "databases" | "devtools" | "learning";
 
-interface AffiliateTool {
-  name: string;
-  category: Exclude<AffiliateCategory, "all">;
-  descriptionEs: string;
-  descriptionEn: string;
-  url: string;
-  icon: ElementType;
-  accent: string;
-}
-
-const AFFILIATE_TOOLS: AffiliateTool[] = [
-  {
-    name: "Udemy",
-    category: "learning",
-    descriptionEs: "Cursos de Playwright, ISTQB, Next.js y QA automation con descuentos frecuentes. Ideal para juniors que quieren aprender con proyectos reales.",
-    descriptionEn: "Playwright, ISTQB, Next.js and QA automation courses with frequent discounts. Great for juniors learning with real projects.",
-    url: "#", // TODO: sustituir por link de afiliado de Udemy (Impact.com)
-    icon: FiBookOpen,
-    accent: "#A435F0",
-  },
-];
-
 const AFFILIATE_CATEGORY_LABELS: Record<AffiliateCategory, { es: string; en: string }> = {
-  all:       { es: "Todas",                  en: "All" },
-  testing:   { es: "Testing y QA",           en: "Testing & QA" },
-  hosting:   { es: "Infraestructura",        en: "Infrastructure" },
-  databases: { es: "Bases de datos",         en: "Databases" },
-  devtools:  { es: "Herramientas dev",       en: "Dev tools" },
-  learning:  { es: "Aprendizaje",            en: "Learning" },
+  all:       { es: "Todas",             en: "All" },
+  testing:   { es: "Testing y QA",      en: "Testing & QA" },
+  hosting:   { es: "Infraestructura",   en: "Infrastructure" },
+  databases: { es: "Bases de datos",    en: "Databases" },
+  devtools:  { es: "Herramientas dev",  en: "Dev tools" },
+  learning:  { es: "Aprendizaje",       en: "Learning" },
 };
 
 const AFFILIATE_CATEGORIES: AffiliateCategory[] = ["all", "testing", "hosting", "databases", "devtools", "learning"];
@@ -73,6 +48,7 @@ export default function RecursosPage() {
   const [currentPage, setCurrentPage] = useState(1);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [affiliateCategory, setAffiliateCategory] = useState<AffiliateCategory>("all");
+  const [affiliateTools, setAffiliateTools] = useState<AffiliateTool[]>([]);
   const filterRef = useRef<HTMLDivElement>(null);
 
   const languageFilter = locale.toUpperCase();
@@ -129,6 +105,18 @@ export default function RecursosPage() {
     void fetchResourceCategories();
   }, [fetchResourceCategories]);
 
+  useEffect(() => {
+    void (async () => {
+      const { data } = await supabase
+        .from("affiliate_tools")
+        .select("*")
+        .eq("active", true)
+        .order("sort_order", { ascending: true })
+        .order("id", { ascending: true });
+      setAffiliateTools((data as AffiliateTool[]) ?? []);
+    })();
+  }, []);
+
   useEffect(() => { void fetchResourcePosts(); }, [fetchResourcePosts]);
 
   useEffect(() => {
@@ -166,9 +154,9 @@ export default function RecursosPage() {
 
   const filteredAffiliateTools = useMemo(() =>
     affiliateCategory === "all"
-      ? AFFILIATE_TOOLS
-      : AFFILIATE_TOOLS.filter((tool) => tool.category === affiliateCategory),
-    [affiliateCategory]
+      ? affiliateTools
+      : affiliateTools.filter((tool) => tool.category === affiliateCategory),
+    [affiliateCategory, affiliateTools]
   );
 
   const isEs = locale === "es";
@@ -243,48 +231,52 @@ export default function RecursosPage() {
           </div>
 
           {/* Tools grid */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-            {filteredAffiliateTools.map((tool) => {
-              const Icon = tool.icon;
-              const description = isEs ? tool.descriptionEs : tool.descriptionEn;
-              const categoryLabel = isEs
-                ? AFFILIATE_CATEGORY_LABELS[tool.category].es
-                : AFFILIATE_CATEGORY_LABELS[tool.category].en;
+          {filteredAffiliateTools.length === 0 ? (
+            <p className="text-center text-gray-500 dark:text-white/40 text-sm py-8">
+              {isEs ? "No hay herramientas en esta categoría todavía." : "No tools in this category yet."}
+            </p>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+              {filteredAffiliateTools.map((tool) => {
+                const description = isEs ? tool.description_es : tool.description_en;
+                const cat = tool.category as AffiliateCategory;
+                const categoryLabel = AFFILIATE_CATEGORY_LABELS[cat]
+                  ? (isEs ? AFFILIATE_CATEGORY_LABELS[cat].es : AFFILIATE_CATEGORY_LABELS[cat].en)
+                  : tool.category;
 
-              return (
-                <Card key={tool.name} className="p-5 flex flex-col gap-4 hover:border-[#00aaff]/40 transition-all duration-300 group">
-                  <div className="flex items-start justify-between gap-3">
+                return (
+                  <Card key={tool.id} className="p-5 flex flex-col gap-4 hover:border-[#00aaff]/40 transition-all duration-300 group">
                     <div className="flex items-center gap-3">
                       <div
-                        className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
-                        style={{ backgroundColor: `${tool.accent}1A`, border: `1px solid ${tool.accent}40` }}
+                        className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0 text-sm font-bold"
+                        style={{ backgroundColor: `${tool.accent_color}1A`, border: `1px solid ${tool.accent_color}40`, color: tool.accent_color }}
                       >
-                        <Icon className="w-5 h-5 shrink-0" style={{ color: tool.accent }} />
+                        {tool.platform.slice(0, 2).toUpperCase()}
                       </div>
                       <div>
                         <p className="font-semibold text-gray-900 dark:text-white leading-tight">{tool.name}</p>
-                        <span className="text-xs text-gray-500 dark:text-white/40">{categoryLabel}</span>
+                        <span className="text-xs text-gray-500 dark:text-white/40">{tool.platform} · {categoryLabel}</span>
                       </div>
                     </div>
-                  </div>
 
-                  <p className="text-sm text-gray-600 dark:text-white/70 leading-relaxed flex-1">
-                    {description}
-                  </p>
+                    <p className="text-sm text-gray-600 dark:text-white/70 leading-relaxed flex-1">
+                      {description}
+                    </p>
 
-                  <a
-                    href={tool.url}
-                    target="_blank"
-                    rel="noopener noreferrer sponsored"
-                    className="inline-flex items-center gap-2 text-sm font-medium text-[#00aaff] hover:text-[#007EAD] transition-colors duration-200 group-hover:gap-3"
-                  >
-                    {isEs ? "Ver herramienta" : "Visit tool"}
-                    <FiExternalLink className="w-3.5 h-3.5 shrink-0" />
-                  </a>
-                </Card>
-              );
-            })}
-          </div>
+                    <a
+                      href={tool.url}
+                      target="_blank"
+                      rel="noopener noreferrer sponsored"
+                      className="inline-flex items-center gap-2 text-sm font-medium text-[#00aaff] hover:text-[#007EAD] transition-colors duration-200 group-hover:gap-3"
+                    >
+                      {isEs ? "Ver herramienta" : "Visit tool"}
+                      <FiExternalLink className="w-3.5 h-3.5 shrink-0" />
+                    </a>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
 
           {/* Affiliate disclosure */}
           <p className="mt-6 text-xs text-gray-400 dark:text-white/30 text-center">

--- a/src/types/affiliate.ts
+++ b/src/types/affiliate.ts
@@ -1,0 +1,16 @@
+export interface AffiliateTool {
+  id: number;
+  name: string;
+  platform: string;
+  category: string;
+  description_es: string;
+  description_en: string;
+  url: string;
+  accent_color: string;
+  active: boolean;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export type AffiliateToolInsert = Omit<AffiliateTool, "id" | "created_at" | "updated_at">;

--- a/supabase/migrations/006_create_affiliate_tools.sql
+++ b/supabase/migrations/006_create_affiliate_tools.sql
@@ -1,0 +1,51 @@
+-- ============================================
+-- Affiliate Tools - Supabase Migration
+-- ============================================
+
+create table if not exists affiliate_tools (
+  id serial primary key,
+  name text not null,
+  platform text not null,             -- 'Udemy', 'DigitalOcean', etc.
+  category text not null,             -- 'learning' | 'testing' | 'hosting' | 'databases' | 'devtools'
+  description_es text not null default '',
+  description_en text not null default '',
+  url text not null,                  -- affiliate link
+  accent_color text not null default '#00aaff',
+  active boolean not null default true,
+  sort_order integer not null default 0,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- Habilitar Row Level Security
+alter table affiliate_tools enable row level security;
+
+-- Política: lectura pública (la página /recursos es pública)
+create policy "public read active affiliate tools"
+  on affiliate_tools for select
+  using (active = true);
+
+-- Política: solo usuarios autenticados (admin) pueden insertar, actualizar, eliminar
+create policy "authenticated users can manage affiliate tools"
+  on affiliate_tools for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+-- Índice para filtrar por categoría
+create index if not exists idx_affiliate_tools_category on affiliate_tools(category);
+
+-- Índice para ordenar
+create index if not exists idx_affiliate_tools_sort on affiliate_tools(sort_order, id);
+
+-- Trigger para updated_at automático
+create or replace function update_affiliate_tools_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger affiliate_tools_updated_at
+  before update on affiliate_tools
+  for each row execute function update_affiliate_tools_updated_at();


### PR DESCRIPTION
## Summary

- Añade tab **Afiliados** en `/admin` con CRUD completo (crear, editar, eliminar, activar/desactivar herramientas)
- `/recursos` ahora carga las herramientas desde Supabase (`affiliate_tools`) en lugar de datos hardcodeados
- Permite recomendar cursos específicos (ej. curso de Playwright en Udemy) en lugar de plataformas genéricas
- Los links de afiliado se añadirán desde `/admin` conforme se vayan aprobando los programas

## Test plan
- [x] Entrar a `/admin` → tab "Afiliados" → crear una herramienta de prueba
- [x] Verificar que aparece en `/recursos` con el color y categoría correctos
- [x] Desactivar la herramienta → verificar que desaparece de `/recursos`
- [x] Eliminar la herramienta de prueba

🤖 Generated with [Claude Code](https://claude.com/claude-code)