### PR TITLE
fix(api): migrar Vercel Functions a React Router resource routes

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -41,6 +41,16 @@ export default [
   route("academia/:category", "pages/academia/AcademiaCategoryPage.tsx"),
   route("academia/:category/:slug", "pages/academia/AcademiaExamPage.tsx"),
 
+  // API resource routes — must be before the wildcard
+  route("api/guia-checkout", "routes/api.guia-checkout.ts"),
+  route("api/academia-checkout", "routes/api.academia-checkout.ts"),
+  route("api/boilerplate-checkout", "routes/api.boilerplate-checkout.ts"),
+  route("api/guia-webhook", "routes/api.guia-webhook.ts"),
+  route("api/customer-portal", "routes/api.customer-portal.ts"),
+  route("api/guia-chapter", "routes/api.guia-chapter.ts"),
+  route("api/newsletter-subscribe", "routes/api.newsletter-subscribe.ts"),
+  route("api/og", "routes/api.og.ts"),
+
   // Fallback 404
   route("*", "pages/NotFoundPage.tsx"),
 ] satisfies RouteConfig;

--- a/src/routes/api.academia-checkout.ts
+++ b/src/routes/api.academia-checkout.ts
@@ -1,10 +1,6 @@
 import type { ActionFunctionArgs } from "react-router";
 import Stripe from "stripe";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: "2025-01-27.acacia" as Stripe.LatestApiVersion,
-});
-
 export async function action({ request }: ActionFunctionArgs) {
   if (request.method !== "POST") {
     return new Response("Method Not Allowed", { status: 405 });
@@ -16,6 +12,9 @@ export async function action({ request }: ActionFunctionArgs) {
       return new Response(JSON.stringify({ error: "Missing required fields" }), { status: 400 });
     }
 
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: "2025-01-27.acacia" as Stripe.LatestApiVersion,
+    });
     const price = await stripe.prices.retrieve(priceId);
     const mode = price.type === "recurring" ? "subscription" : "payment";
 

--- a/src/routes/api.academia-checkout.ts
+++ b/src/routes/api.academia-checkout.ts
@@ -1,0 +1,42 @@
+import type { ActionFunctionArgs } from "react-router";
+import Stripe from "stripe";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: "2025-01-27.acacia" as Stripe.LatestApiVersion,
+});
+
+export async function action({ request }: ActionFunctionArgs) {
+  if (request.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  try {
+    const { priceId, userId, email } = await request.json();
+
+    if (!priceId) {
+      return new Response(JSON.stringify({ error: "Missing required fields" }), { status: 400 });
+    }
+
+    const price = await stripe.prices.retrieve(priceId);
+    const mode = price.type === "recurring" ? "subscription" : "payment";
+
+    const session = await stripe.checkout.sessions.create({
+      mode,
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: `${process.env.BASE_URL || "http://localhost:5173"}/academia/gracias?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${process.env.BASE_URL || "http://localhost:5173"}/academia`,
+      ...(email ? { customer_email: email } : {}),
+      customer_creation: mode === "payment" ? "always" : undefined,
+      allow_promotion_codes: true,
+      metadata: {
+        userId: userId ?? "",
+        product: "academia",
+      },
+    });
+
+    return new Response(JSON.stringify({ url: session.url }), { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error("Academia checkout error:", message);
+    return new Response(JSON.stringify({ error: message }), { status: 500 });
+  }
+}

--- a/src/routes/api.boilerplate-checkout.ts
+++ b/src/routes/api.boilerplate-checkout.ts
@@ -1,10 +1,6 @@
 import type { ActionFunctionArgs } from "react-router";
 import Stripe from "stripe";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: "2025-01-27.acacia" as Stripe.LatestApiVersion,
-});
-
 export async function action({ request }: ActionFunctionArgs) {
   if (request.method !== "POST") {
     return new Response("Method Not Allowed", { status: 405 });
@@ -16,6 +12,9 @@ export async function action({ request }: ActionFunctionArgs) {
       return new Response(JSON.stringify({ error: "Missing required fields" }), { status: 400 });
     }
 
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: "2025-01-27.acacia" as Stripe.LatestApiVersion,
+    });
     const session = await stripe.checkout.sessions.create({
       mode: "payment",
       line_items: [{ price: priceId, quantity: 1 }],

--- a/src/routes/api.boilerplate-checkout.ts
+++ b/src/routes/api.boilerplate-checkout.ts
@@ -1,0 +1,38 @@
+import type { ActionFunctionArgs } from "react-router";
+import Stripe from "stripe";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: "2025-01-27.acacia" as Stripe.LatestApiVersion,
+});
+
+export async function action({ request }: ActionFunctionArgs) {
+  if (request.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  try {
+    const { priceId, userId, email } = await request.json();
+
+    if (!priceId || !userId || !email) {
+      return new Response(JSON.stringify({ error: "Missing required fields" }), { status: 400 });
+    }
+
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: `${process.env.BASE_URL || "http://localhost:5173"}/arkeonix/gracias?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${process.env.BASE_URL || "http://localhost:5173"}/arkeonix`,
+      customer_email: email,
+      allow_promotion_codes: true,
+      metadata: {
+        userId,
+        product: "boilerplate",
+      },
+    });
+
+    return new Response(JSON.stringify({ url: session.url }), { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error("Boilerplate checkout error:", message);
+    return new Response(JSON.stringify({ error: message }), { status: 500 });
+  }
+}

--- a/src/routes/api.customer-portal.ts
+++ b/src/routes/api.customer-portal.ts
@@ -2,19 +2,17 @@ import type { ActionFunctionArgs } from "react-router";
 import Stripe from "stripe";
 import { createClient } from "@supabase/supabase-js";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: "2025-01-27.acacia" as Stripe.LatestApiVersion,
-});
-
-const supabaseAdmin = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
-
 export async function action({ request }: ActionFunctionArgs) {
   if (request.method !== "POST") {
     return new Response("Method Not Allowed", { status: 405 });
   }
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+    apiVersion: "2025-01-27.acacia" as Stripe.LatestApiVersion,
+  });
+  const supabaseAdmin = createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
   try {
     const { userId } = await request.json();
 

--- a/src/routes/api.customer-portal.ts
+++ b/src/routes/api.customer-portal.ts
@@ -1,0 +1,48 @@
+import type { ActionFunctionArgs } from "react-router";
+import Stripe from "stripe";
+import { createClient } from "@supabase/supabase-js";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: "2025-01-27.acacia" as Stripe.LatestApiVersion,
+});
+
+const supabaseAdmin = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+export async function action({ request }: ActionFunctionArgs) {
+  if (request.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  try {
+    const { userId } = await request.json();
+
+    if (!userId) {
+      return new Response(JSON.stringify({ error: "Missing userId" }), { status: 400 });
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from("user_access")
+      .select("stripe_customer_id")
+      .eq("user_id", userId)
+      .not("stripe_customer_id", "is", null)
+      .limit(1)
+      .single();
+
+    if (error || !data?.stripe_customer_id) {
+      return new Response(JSON.stringify({ error: "No Stripe customer found" }), { status: 404 });
+    }
+
+    const session = await stripe.billingPortal.sessions.create({
+      customer: data.stripe_customer_id,
+      return_url: `${process.env.BASE_URL || "http://localhost:5173"}/guia-junior/dashboard`,
+    });
+
+    return new Response(JSON.stringify({ url: session.url }), { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error("Customer portal error:", message);
+    return new Response(JSON.stringify({ error: message }), { status: 500 });
+  }
+}

--- a/src/routes/api.guia-chapter.ts
+++ b/src/routes/api.guia-chapter.ts
@@ -1,12 +1,11 @@
 import type { LoaderFunctionArgs } from "react-router";
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseAdmin = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
-
 export async function loader({ request }: LoaderFunctionArgs) {
+  const supabaseAdmin = createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
   try {
     const url = new URL(request.url);
     const slug = url.searchParams.get("slug");

--- a/src/routes/api.guia-chapter.ts
+++ b/src/routes/api.guia-chapter.ts
@@ -1,0 +1,71 @@
+import type { LoaderFunctionArgs } from "react-router";
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseAdmin = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  try {
+    const url = new URL(request.url);
+    const slug = url.searchParams.get("slug");
+
+    if (!slug) {
+      return new Response(JSON.stringify({ error: "Missing slug parameter" }), { status: 400 });
+    }
+
+    const cookie = request.headers.get("cookie") || "";
+    const sessionMatch = cookie.match(/sb-[^=]+=([^;]+)/);
+    const accessToken = sessionMatch ? decodeURIComponent(sessionMatch[1]) : null;
+
+    if (!accessToken) {
+      return new Response(JSON.stringify({ error: "Not authenticated" }), { status: 401 });
+    }
+
+    const { data: { user }, error: authError } = await supabaseAdmin.auth.getUser(accessToken);
+    if (authError || !user) {
+      return new Response(JSON.stringify({ error: "Invalid session" }), { status: 401 });
+    }
+
+    const { data: chapter, error: chapterError } = await supabaseAdmin
+      .from("guia_chapters")
+      .select('slug, title, content, is_free, "order"')
+      .eq("slug", slug)
+      .single();
+
+    if (chapterError || !chapter) {
+      return new Response(JSON.stringify({ error: "Chapter not found" }), { status: 404 });
+    }
+
+    if (chapter.is_free) {
+      return new Response(JSON.stringify({ chapter }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const { data: access } = await supabaseAdmin
+      .from("user_access")
+      .select("id")
+      .eq("user_id", user.id)
+      .eq("product_id", "guia_junior")
+      .eq("status", "active")
+      .single();
+
+    if (!access) {
+      return new Response(
+        JSON.stringify({ error: "Access denied. Premium content requires active subscription." }),
+        { status: 403 }
+      );
+    }
+
+    return new Response(JSON.stringify({ chapter }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error("Chapter API error:", error);
+    return new Response(JSON.stringify({ error: "Internal server error" }), { status: 500 });
+  }
+}

--- a/src/routes/api.guia-checkout.ts
+++ b/src/routes/api.guia-checkout.ts
@@ -1,10 +1,6 @@
 import type { ActionFunctionArgs } from "react-router";
 import Stripe from "stripe";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: "2025-01-27.acacia" as Stripe.LatestApiVersion,
-});
-
 export async function action({ request }: ActionFunctionArgs) {
   if (request.method !== "POST") {
     return new Response("Method Not Allowed", { status: 405 });
@@ -16,6 +12,9 @@ export async function action({ request }: ActionFunctionArgs) {
       return new Response(JSON.stringify({ error: "Missing required fields" }), { status: 400 });
     }
 
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: "2025-01-27.acacia" as Stripe.LatestApiVersion,
+    });
     const price = await stripe.prices.retrieve(priceId);
     const mode = price.type === "recurring" ? "subscription" : "payment";
 

--- a/src/routes/api.guia-checkout.ts
+++ b/src/routes/api.guia-checkout.ts
@@ -1,0 +1,43 @@
+import type { ActionFunctionArgs } from "react-router";
+import Stripe from "stripe";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: "2025-01-27.acacia" as Stripe.LatestApiVersion,
+});
+
+export async function action({ request }: ActionFunctionArgs) {
+  if (request.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  try {
+    const { priceId, userId, email, isB2B, b2bType } = await request.json();
+
+    if (!priceId) {
+      return new Response(JSON.stringify({ error: "Missing required fields" }), { status: 400 });
+    }
+
+    const price = await stripe.prices.retrieve(priceId);
+    const mode = price.type === "recurring" ? "subscription" : "payment";
+
+    const session = await stripe.checkout.sessions.create({
+      mode,
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: `${process.env.BASE_URL || "http://localhost:5173"}/guia-junior/gracias?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${process.env.BASE_URL || "http://localhost:5173"}/guia-junior`,
+      ...(email ? { customer_email: email } : {}),
+      customer_creation: mode === "payment" ? "always" : undefined,
+      allow_promotion_codes: true,
+      metadata: {
+        userId: userId ?? "",
+        product: isB2B ? "guia_junior_b2b" : "guia_junior",
+        b2bType: isB2B ? b2bType : "",
+      },
+    });
+
+    return new Response(JSON.stringify({ url: session.url }), { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error("Guia checkout error:", message);
+    return new Response(JSON.stringify({ error: message }), { status: 500 });
+  }
+}

--- a/src/routes/api.guia-webhook.ts
+++ b/src/routes/api.guia-webhook.ts
@@ -1,0 +1,152 @@
+import type { ActionFunctionArgs } from "react-router";
+import Stripe from "stripe";
+import { createClient } from "@supabase/supabase-js";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: "2025-01-27.acacia" as Stripe.LatestApiVersion,
+});
+
+const supabaseAdmin = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET!;
+
+function getSubscriptionId(invoice: Stripe.Invoice): string | null {
+  const sub = invoice.parent?.subscription_details?.subscription ?? null;
+  if (!sub) return null;
+  return typeof sub === "string" ? sub : sub.id;
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  if (request.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  try {
+    const body = await request.text();
+    const sig = request.headers.get("stripe-signature")!;
+
+    if (body.includes('"v2.core.event"')) {
+      return new Response("OK", { status: 200 });
+    }
+
+    let event: Stripe.Event;
+    try {
+      event = stripe.webhooks.constructEvent(body, sig, webhookSecret);
+    } catch (err) {
+      console.error("Webhook signature verification failed:", err);
+      return new Response("Webhook error", { status: 400 });
+    }
+
+    if (event.type === "checkout.session.completed") {
+      const session = event.data.object as Stripe.Checkout.Session;
+      const { userId: rawUserId, product: metadataProduct, b2bType } = session.metadata as {
+        userId: string;
+        product: string;
+        b2bType: string;
+      };
+
+      let userId = rawUserId;
+      if (!userId) {
+        const customerEmail = session.customer_details?.email;
+        if (customerEmail) {
+          const { data: inviteData, error: inviteError } =
+            await supabaseAdmin.auth.admin.inviteUserByEmail(customerEmail);
+          if (inviteData?.user) {
+            userId = inviteData.user.id;
+          } else if (
+            inviteError?.message?.toLowerCase().includes("already been registered") ||
+            inviteError?.message?.toLowerCase().includes("already registered")
+          ) {
+            const { data: listData } = await supabaseAdmin.auth.admin.listUsers({ perPage: 1000 });
+            const existing = listData?.users.find((u) => u.email === customerEmail);
+            if (existing) {
+              userId = existing.id;
+              await supabaseAdmin.auth.admin.generateLink({ type: "magiclink", email: customerEmail });
+            }
+          }
+        }
+        if (!userId) {
+          console.error("Could not resolve userId for guest checkout session:", session.id);
+          return new Response("Could not resolve user", { status: 500 });
+        }
+      }
+
+      const fullSession = await stripe.checkout.sessions.retrieve(session.id, {
+        expand: ["line_items"],
+      });
+      const priceId = fullSession.line_items?.data[0]?.price?.id;
+
+      let productId = metadataProduct;
+      let plan = "lifetime";
+
+      if (metadataProduct === "boilerplate") {
+        plan = priceId === process.env.STRIPE_PRICE_BOILERPLATE_PRO ? "pro" : "starter";
+      } else if (metadataProduct === "guia_junior_b2b") {
+        productId = "guia_junior_b2b";
+        plan = b2bType === "annual" ? "b2b_annual" : "b2b_lifetime";
+      } else {
+        if (priceId === process.env.STRIPE_PRICE_GUIA_MONTHLY) plan = "monthly";
+        else if (priceId === process.env.STRIPE_PRICE_GUIA_ANNUAL) plan = "annual";
+        else if (priceId === process.env.STRIPE_PRICE_GUIA_LIFETIME) plan = "lifetime";
+        else if (priceId === process.env.STRIPE_PRICE_GUIA_LIFETIME_NORMAL) plan = "lifetime_normal";
+      }
+
+      let expiresAt: string | null = null;
+      if (plan === "monthly") {
+        expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+      } else if (plan === "annual" || plan === "b2b_annual") {
+        expiresAt = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString();
+      }
+
+      const { error } = await supabaseAdmin.from("user_access").insert({
+        user_id: userId,
+        product_id: productId,
+        plan,
+        status: "active",
+        stripe_customer_id: session.customer as string,
+        stripe_subscription_id: session.subscription as string | null,
+        expires_at: expiresAt,
+      });
+
+      if (error) {
+        console.error("Error inserting user_access:", error);
+        return new Response(
+          JSON.stringify({ error: error.message, code: error.code, details: error.details }),
+          { status: 500, headers: { "Content-Type": "application/json" } }
+        );
+      }
+    } else if (event.type === "invoice.payment_failed") {
+      const invoice = event.data.object as Stripe.Invoice;
+      const subscriptionId = getSubscriptionId(invoice);
+      if (subscriptionId) {
+        await supabaseAdmin
+          .from("user_access")
+          .update({ status: "past_due" })
+          .eq("stripe_subscription_id", subscriptionId);
+      }
+    } else if (event.type === "customer.subscription.deleted") {
+      const subscription = event.data.object as Stripe.Subscription;
+      await supabaseAdmin
+        .from("user_access")
+        .update({ status: "cancelled", expires_at: new Date().toISOString() })
+        .eq("stripe_subscription_id", subscription.id);
+    } else if (event.type === "invoice.payment_succeeded") {
+      const invoice = event.data.object as Stripe.Invoice;
+      const subscriptionId = getSubscriptionId(invoice);
+      if (subscriptionId && invoice.billing_reason === "subscription_cycle") {
+        const nextBilling = new Date(invoice.lines.data[0]?.period.end * 1000);
+        await supabaseAdmin
+          .from("user_access")
+          .update({ expires_at: nextBilling.toISOString(), status: "active" })
+          .eq("stripe_subscription_id", subscriptionId);
+      }
+    }
+
+    return new Response("OK", { status: 200 });
+  } catch (error) {
+    console.error("Webhook handler error:", error);
+    return new Response("Internal server error", { status: 500 });
+  }
+}

--- a/src/routes/api.guia-webhook.ts
+++ b/src/routes/api.guia-webhook.ts
@@ -2,17 +2,6 @@ import type { ActionFunctionArgs } from "react-router";
 import Stripe from "stripe";
 import { createClient } from "@supabase/supabase-js";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: "2025-01-27.acacia" as Stripe.LatestApiVersion,
-});
-
-const supabaseAdmin = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
-
-const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET!;
-
 function getSubscriptionId(invoice: Stripe.Invoice): string | null {
   const sub = invoice.parent?.subscription_details?.subscription ?? null;
   if (!sub) return null;
@@ -23,6 +12,14 @@ export async function action({ request }: ActionFunctionArgs) {
   if (request.method !== "POST") {
     return new Response("Method Not Allowed", { status: 405 });
   }
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+    apiVersion: "2025-01-27.acacia" as Stripe.LatestApiVersion,
+  });
+  const supabaseAdmin = createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET!;
   try {
     const body = await request.text();
     const sig = request.headers.get("stripe-signature")!;

--- a/src/routes/api.newsletter-subscribe.ts
+++ b/src/routes/api.newsletter-subscribe.ts
@@ -1,0 +1,75 @@
+import type { ActionFunctionArgs } from "react-router";
+import { Resend } from "resend";
+import { createClient } from "@supabase/supabase-js";
+import { renderWelcomeEmail } from "@/emails/welcome-email-html";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function action({ request }: ActionFunctionArgs) {
+  if (request.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  let email: string;
+  try {
+    const body = (await request.json()) as { email?: unknown };
+    email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+  } catch {
+    return new Response(JSON.stringify({ error: "invalid_json" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (!EMAIL_REGEX.test(email)) {
+    return new Response(JSON.stringify({ error: "invalid_email" }), {
+      status: 422,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const supabase = createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+
+  const { error: dbError } = await supabase.from("newsletter_subscribers").insert({ email });
+
+  if (dbError) {
+    if (dbError.code === "23505") {
+      return new Response(JSON.stringify({ error: "duplicate_email" }), {
+        status: 409,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    console.error("Supabase insert error:", dbError);
+    return new Response(JSON.stringify({ error: "db_error" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const resendApiKey = process.env.RESEND_API_KEY;
+  if (resendApiKey) {
+    try {
+      const resend = new Resend(resendApiKey);
+      const html = renderWelcomeEmail(email);
+      await resend.emails.send({
+        from: "Arkeonix Labs <newsletter@arkeonixlabs.com>",
+        to: email,
+        subject: "Welcome to Arkeonix Labs 🔬",
+        html,
+      });
+    } catch (emailError) {
+      console.error("Resend email error:", emailError);
+    }
+  }
+
+  return new Response(JSON.stringify({ success: true }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/routes/api.og.ts
+++ b/src/routes/api.og.ts
@@ -1,0 +1,191 @@
+import type { LoaderFunctionArgs } from "react-router";
+import { ImageResponse } from "@vercel/og";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { searchParams } = new URL(request.url);
+  const title = searchParams.get("title") ?? "Arkeonix Labs";
+  const category = searchParams.get("category") ?? "";
+  const author = searchParams.get("author") ?? "Arkeonix Labs";
+
+  const displayTitle = title.length > 70 ? title.slice(0, 67) + "…" : title;
+
+  return new ImageResponse(
+    ({
+      type: "div",
+      props: {
+        style: {
+          width: "1200px",
+          height: "630px",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "64px",
+          background: "linear-gradient(135deg, #080b16 0%, #0d1425 50%, #0a1020 100%)",
+          fontFamily: "system-ui, sans-serif",
+          position: "relative",
+          overflow: "hidden",
+        },
+        children: [
+          {
+            type: "div",
+            props: {
+              style: {
+                position: "absolute",
+                top: "-120px",
+                left: "-120px",
+                width: "500px",
+                height: "500px",
+                borderRadius: "50%",
+                background: "radial-gradient(circle, rgba(99,102,241,0.15) 0%, transparent 70%)",
+              },
+            },
+          },
+          {
+            type: "div",
+            props: {
+              style: {
+                position: "absolute",
+                bottom: "-100px",
+                right: "-80px",
+                width: "400px",
+                height: "400px",
+                borderRadius: "50%",
+                background: "radial-gradient(circle, rgba(167,139,250,0.1) 0%, transparent 70%)",
+              },
+            },
+          },
+          {
+            type: "div",
+            props: {
+              style: { display: "flex", alignItems: "center", gap: "16px" },
+              children: [
+                {
+                  type: "div",
+                  props: {
+                    style: { display: "flex", alignItems: "center", gap: "10px" },
+                    children: [
+                      {
+                        type: "div",
+                        props: {
+                          style: {
+                            width: "36px",
+                            height: "36px",
+                            borderRadius: "8px",
+                            background: "linear-gradient(135deg, #6366f1, #a78bfa)",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            fontSize: "18px",
+                            fontWeight: "bold",
+                            color: "white",
+                          },
+                          children: "A",
+                        },
+                      },
+                      {
+                        type: "span",
+                        props: {
+                          style: {
+                            color: "rgba(255,255,255,0.9)",
+                            fontWeight: "700",
+                            fontSize: "20px",
+                            letterSpacing: "-0.02em",
+                          },
+                          children: "Arkeonix Labs",
+                        },
+                      },
+                    ],
+                  },
+                },
+                category
+                  ? {
+                      type: "div",
+                      props: {
+                        style: {
+                          width: "1px",
+                          height: "20px",
+                          background: "rgba(255,255,255,0.2)",
+                          marginLeft: "4px",
+                        },
+                      },
+                    }
+                  : null,
+                category
+                  ? {
+                      type: "span",
+                      props: {
+                        style: {
+                          padding: "4px 12px",
+                          borderRadius: "999px",
+                          background: "rgba(99,102,241,0.2)",
+                          border: "1px solid rgba(99,102,241,0.4)",
+                          color: "#a5b4fc",
+                          fontSize: "14px",
+                          fontWeight: "600",
+                          letterSpacing: "0.02em",
+                        },
+                        children: category.toUpperCase(),
+                      },
+                    }
+                  : null,
+              ].filter(Boolean),
+            },
+          },
+          {
+            type: "div",
+            props: {
+              style: {
+                flex: 1,
+                display: "flex",
+                alignItems: "center",
+                paddingTop: "32px",
+                paddingBottom: "32px",
+              },
+              children: {
+                type: "h1",
+                props: {
+                  style: {
+                    fontSize: displayTitle.length > 50 ? "48px" : "60px",
+                    fontWeight: "800",
+                    lineHeight: "1.1",
+                    letterSpacing: "-0.03em",
+                    background: "linear-gradient(135deg, #ffffff 0%, rgba(255,255,255,0.75) 100%)",
+                    backgroundClip: "text",
+                    WebkitBackgroundClip: "text",
+                    color: "transparent",
+                    margin: "0",
+                  },
+                  children: displayTitle,
+                },
+              },
+            },
+          },
+          {
+            type: "div",
+            props: {
+              style: { display: "flex", alignItems: "center", justifyContent: "space-between" },
+              children: [
+                {
+                  type: "span",
+                  props: {
+                    style: { color: "rgba(255,255,255,0.5)", fontSize: "16px" },
+                    children: `By ${author}`,
+                  },
+                },
+                {
+                  type: "span",
+                  props: {
+                    style: { color: "rgba(165,180,252,0.7)", fontSize: "16px", fontWeight: "600" },
+                    children: "arkeonixlabs.com",
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any),
+    { width: 1200, height: 630 }
+  );
+}


### PR DESCRIPTION
## Problema

Los checkouts de todos los productos (Guía Junior, Academia, Boilerplate) devolvían **405 Method Not Allowed** al intentar pagar.

**Root cause**: `vercelPreset()` usa el Vercel Build Output API y enruta **todas** las requests por el handler de React Router SSR. Los ficheros en `/api/` nunca se reconocen como Vercel Functions separadas. Al no existir ruta React Router para `/api/guia-checkout`, la request caía en el wildcard `*` (NotFoundPage) que devolvía 405 al recibir un POST sin `action` definida.

## Solución

Convertir las 8 Vercel Functions en `/api/` a **resource routes de React Router v7** y registrarlas en `src/routes.ts` antes del wildcard `*`.

| Ruta | Tipo | Handler |
|------|------|---------|
| `api/guia-checkout` | POST | `action` |
| `api/academia-checkout` | POST | `action` |
| `api/boilerplate-checkout` | POST | `action` |
| `api/guia-webhook` | POST | `action` |
| `api/customer-portal` | POST | `action` |
| `api/guia-chapter` | GET | `loader` |
| `api/newsletter-subscribe` | POST | `action` |
| `api/og` | GET | `loader` |

La lógica interna de cada función es idéntica — solo cambia el wrapper (`action`/`loader` en lugar de `POST`/`GET` export).

## Test plan

- [ ] Checkout Guía Junior — redirige a Stripe sin 405
- [ ] Checkout Academia — redirige a Stripe sin 405
- [ ] Checkout Boilerplate — redirige a Stripe sin 405
- [ ] Webhook de Stripe procesa `checkout.session.completed` correctamente
- [ ] `/api/og?title=Test` devuelve imagen PNG
- [ ] `pnpm typecheck` sin errores ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)