### PR TITLE
fix(seo): correcciones del audit SEO completo

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,38 @@
+# Arkeonix Labs — llms.txt
+# https://llmstxt.org
+
+> Arkeonix Labs es una plataforma de análisis técnico y contenido de precisión para desarrolladores y profesionales tech.
+
+## About
+
+Arkeonix Labs publica análisis técnicos detallados, guías de infraestructura, reseñas de hardware y recursos seleccionados para desarrolladores. También ofrece productos educativos para developers junior y un SaaS boilerplate empresarial.
+
+## Content
+
+- Blog: https://arkeonixlabs.com/blog — Análisis técnicos y artículos de tecnología
+- Recursos: https://arkeonixlabs.com/recursos — Herramientas, hardware y software recomendado
+- Lab: https://arkeonixlabs.com/lab — Guías técnicas avanzadas de infraestructura y servidores
+- Guía Junior: https://arkeonixlabs.com/guia-junior — Guía de carrera para developers junior
+- Arkeonix SaaS: https://arkeonixlabs.com/arkeonix — Boilerplate empresarial con Next.js 15
+
+## Sitemap
+
+https://arkeonixlabs.com/sitemap.xml
+
+## Contact
+
+https://arkeonixlabs.com/contact
+
+## Language
+
+Primary: Spanish (es-ES)
+Secondary: English (en-US)
+
+## Allowed
+
+User-agent: *
+Allow: /
+
+## robots.txt
+
+https://arkeonixlabs.com/robots.txt

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -40,6 +40,8 @@ export default function Footer() {
               <img
                 src="/arkeonix-logo.png"
                 alt="Arkeonix Labs Logo"
+                width={28}
+                height={28}
                 className="w-7 h-7 rounded-lg object-contain group-hover:scale-105 transition-transform duration-300"
                 style={{
                   boxShadow: "0 2px 6px color-mix(in oklch, var(--color-primary) 15%, transparent)",
@@ -54,7 +56,7 @@ export default function Footer() {
             </p>
             <div className="flex gap-2 pt-1">
               <a
-                href="https://github.com/ArkeonixLabs"
+                href="https://github.com/ArkeonProject"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="p-2 rounded-lg bg-background border border-border/40 text-muted-foreground hover:text-primary hover:border-primary/30 transition-all duration-300"

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -76,6 +76,8 @@ export default function Header() {
             <img
               src="/arkeonix-logo.png"
               alt="Arkeonix Labs Logo"
+              width={32}
+              height={32}
               className={`rounded-lg object-contain transition-all duration-300 group-hover:scale-105 ${isScrolled ? "w-7 h-7" : "w-8 h-8"
                 }`}
               style={{

--- a/src/data/guia/chapter-0.tsx
+++ b/src/data/guia/chapter-0.tsx
@@ -340,8 +340,8 @@ export default function Chapter0() {
           </div>
         </div>
         <div className="bg-foreground text-background rounded-xl p-10 text-center">
-          <p className="text-4xl font-display font-black text-background tracking-tight">Desde 2,99 €/mes</p>
-          <p className="text-base text-background/60 mt-2">O pago único vitalicio desde 9 €</p>
+          <p className="text-4xl font-display font-black text-background tracking-tight">19 €</p>
+          <p className="text-base text-background/60 mt-2">Pago único vitalicio</p>
           <a href="/guia-junior" className="inline-block mt-6 bg-accent text-white text-lg font-bold px-10 py-4 rounded-full no-underline hover:opacity-90 transition-opacity">
             Accede aquí
           </a>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -546,7 +546,6 @@
   "academia_submit": "Submit answers",
   "academia_submit_pending": "Pending",
   "academia_explanation": "Explanation",
-
   "cta_boilerplate_from_chapter_title": "Looking for a real portfolio project?",
   "cta_boilerplate_from_chapter_desc": "The Arkeonix boilerplate includes auth, payments and multi-tenancy out of the box. Use it as your project base and prove you can ship production-grade SaaS.",
   "cta_boilerplate_from_chapter_btn": "See the Boilerplate →",
@@ -559,12 +558,12 @@
   "cta_guia_from_academia_title": "Also preparing the career side?",
   "cta_guia_from_academia_desc": "Passing the exam is not enough. The Junior Guide prepares you for your CV, interview and first real job.",
   "cta_guia_from_academia_btn": "See the Junior Guide →",
-
   "footer_products": "Products",
   "footer_product_guia": "Junior Guide",
   "footer_product_guia_price": "€19 lifetime",
   "footer_product_academia": "QA Academy",
   "footer_product_academia_price": "€19 lifetime",
   "footer_product_boilerplate": "SaaS Boilerplate",
-  "footer_product_boilerplate_price": "from €149"
+  "footer_product_boilerplate_price": "from €149",
+  "a11y_skip_link": "Skip to content"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -547,7 +547,6 @@
   "academia_submit": "Enviar respuestas",
   "academia_submit_pending": "Faltan",
   "academia_explanation": "Explicación",
-
   "cta_boilerplate_from_chapter_title": "¿Buscas un proyecto de portfolio real?",
   "cta_boilerplate_from_chapter_desc": "El boilerplate de Arkeonix tiene auth, pagos y multi-tenancy listos. Úsalo como base de tu proyecto y demuestra que sabes montar un SaaS de producción.",
   "cta_boilerplate_from_chapter_btn": "Ver el Boilerplate →",
@@ -560,12 +559,12 @@
   "cta_guia_from_academia_title": "¿Preparando también la parte laboral?",
   "cta_guia_from_academia_desc": "Aprobar el examen no es suficiente. La Guía Junior te prepara para el CV, la entrevista y el primer empleo real.",
   "cta_guia_from_academia_btn": "Ver la Guía Junior →",
-
   "footer_products": "Productos",
   "footer_product_guia": "Guía Junior",
   "footer_product_guia_price": "€19 lifetime",
   "footer_product_academia": "Academia QA",
   "footer_product_academia_price": "€19 lifetime",
   "footer_product_boilerplate": "SaaS Boilerplate",
-  "footer_product_boilerplate_price": "desde €149"
+  "footer_product_boilerplate_price": "desde €149",
+  "a11y_skip_link": "Saltar al contenido"
 }

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,4 +1,20 @@
 import { Helmet } from "react-helmet-async";
+import type { MetaFunction } from "react-router";
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const meta: MetaFunction = () => [
+  { title: "Sobre Nosotros | Arkeonix Labs" },
+  { name: "description", content: "Conoce al equipo de Arkeonix Labs y nuestra misión de precisión técnica en análisis de tecnología." },
+  { tagName: "link", rel: "canonical", href: "https://arkeonixlabs.com/about" },
+  { property: "og:title", content: "Sobre Nosotros | Arkeonix Labs" },
+  { property: "og:description", content: "Conoce al equipo de Arkeonix Labs y nuestra misión de precisión técnica en análisis de tecnología." },
+  { property: "og:image", content: "https://arkeonixlabs.com/arkeonix-logo.png" },
+  { property: "og:url", content: "https://arkeonixlabs.com/about" },
+  { name: "twitter:card", content: "summary_large_image" },
+  { name: "twitter:title", content: "Sobre Nosotros | Arkeonix Labs" },
+  { name: "twitter:description", content: "Conoce al equipo de Arkeonix Labs y nuestra misión de precisión técnica en análisis de tecnología." },
+  { name: "twitter:image", content: "https://arkeonixlabs.com/arkeonix-logo.png" },
+];
 import { useLocale } from "@/hooks/useLocale";
 import ScrollReveal from "@/components/ui/ScrollReveal";
 

--- a/src/pages/ArkeonixPage.tsx
+++ b/src/pages/ArkeonixPage.tsx
@@ -1,6 +1,22 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router";
 import { Helmet } from "react-helmet-async";
+import type { MetaFunction } from "react-router";
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const meta: MetaFunction = () => [
+  { title: "Arkeonix SaaS — Enterprise Boilerplate con Next.js 15 | Arkeonix Labs" },
+  { name: "description", content: "Arkeonix SaaS es un boilerplate listo para producción con autenticación, pagos con Stripe, multi-tenancy y RBAC. Lanza tu SaaS en días, no meses." },
+  { tagName: "link", rel: "canonical", href: "https://arkeonixlabs.com/arkeonix" },
+  { property: "og:title", content: "Arkeonix SaaS — Enterprise Boilerplate | Arkeonix Labs" },
+  { property: "og:description", content: "Arkeonix SaaS es un boilerplate listo para producción con autenticación, pagos con Stripe, multi-tenancy y RBAC. Lanza tu SaaS en días, no meses." },
+  { property: "og:image", content: "https://arkeonixlabs.com/arkeonix-logo.png" },
+  { property: "og:url", content: "https://arkeonixlabs.com/arkeonix" },
+  { name: "twitter:card", content: "summary_large_image" },
+  { name: "twitter:title", content: "Arkeonix SaaS — Enterprise Boilerplate | Arkeonix Labs" },
+  { name: "twitter:description", content: "Arkeonix SaaS es un boilerplate listo para producción con autenticación, pagos con Stripe, multi-tenancy y RBAC. Lanza tu SaaS en días, no meses." },
+  { name: "twitter:image", content: "https://arkeonixlabs.com/arkeonix-logo.png" },
+];
 import { useLocale } from "@/hooks/useLocale";
 import { useAuth } from "@/context/AuthContext";
 import {

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -1,6 +1,26 @@
 import { useEffect, useState, useCallback } from "react";
 import { Helmet } from "react-helmet-async";
 import { Link } from "react-router";
+import type { MetaFunction } from "react-router";
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const meta: MetaFunction = ({ location }) => {
+  const isHome = location.pathname === "/";
+  const url = isHome ? "https://arkeonixlabs.com/" : "https://arkeonixlabs.com/blog";
+  return [
+    { title: "Arkeonix Labs — Precisión Técnica" },
+    { name: "description", content: "Análisis técnicos y vanguardia tecnológica por Arkeonix Labs." },
+    { tagName: "link", rel: "canonical", href: url },
+    { property: "og:title", content: "Arkeonix Labs — Precisión Técnica" },
+    { property: "og:description", content: "Análisis técnicos y vanguardia tecnológica por Arkeonix Labs." },
+    { property: "og:image", content: "https://arkeonixlabs.com/arkeonix-logo.png" },
+    { property: "og:url", content: url },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:title", content: "Arkeonix Labs — Precisión Técnica" },
+    { name: "twitter:description", content: "Análisis técnicos y vanguardia tecnológica por Arkeonix Labs." },
+    { name: "twitter:image", content: "https://arkeonixlabs.com/arkeonix-logo.png" },
+  ];
+};
 import { FiTerminal, FiSearch, FiCode, FiFileText } from "react-icons/fi";
 import NewsletterForm from "@/components/forms/NewsletterForm";
 import InfiniteCarousel from "@/components/layout/InfiniteCarousel";

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -1,5 +1,17 @@
 import { useState, type FormEvent } from "react";
 import { Helmet } from "react-helmet-async";
+import type { MetaFunction } from "react-router";
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const meta: MetaFunction = () => [
+  { title: "Contacto | Arkeonix Labs" },
+  { name: "description", content: "Ponte en contacto con el equipo de Arkeonix Labs para consultas técnicas o colaboraciones." },
+  { tagName: "link", rel: "canonical", href: "https://arkeonixlabs.com/contact" },
+  { property: "og:title", content: "Contacto | Arkeonix Labs" },
+  { property: "og:description", content: "Ponte en contacto con el equipo de Arkeonix Labs para consultas técnicas o colaboraciones." },
+  { property: "og:url", content: "https://arkeonixlabs.com/contact" },
+  { name: "twitter:card", content: "summary" },
+];
 import { useLocale } from "@/hooks/useLocale";
 import { FiMail, FiUser, FiMessageSquare, FiSend } from "react-icons/fi";
 import ScrollReveal from "@/components/ui/ScrollReveal";

--- a/src/pages/CookiesPolicyPage.tsx
+++ b/src/pages/CookiesPolicyPage.tsx
@@ -1,4 +1,13 @@
 import { Helmet } from "react-helmet-async";
+import type { MetaFunction } from "react-router";
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const meta: MetaFunction = () => [
+  { title: "Política de Cookies | Arkeonix Labs" },
+  { name: "description", content: "Explicamos cómo gestionamos las cookies para optimizar tu experiencia técnica en nuestro sitio." },
+  { tagName: "link", rel: "canonical", href: "https://arkeonixlabs.com/cookies" },
+  { name: "robots", content: "noindex, follow" },
+];
 import { useLocale } from "@/hooks/useLocale";
 import ScrollReveal from "@/components/ui/ScrollReveal";
 

--- a/src/pages/LabPage.tsx
+++ b/src/pages/LabPage.tsx
@@ -1,5 +1,21 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
 import { Helmet } from "react-helmet-async";
+import type { MetaFunction } from "react-router";
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const meta: MetaFunction = () => [
+  { title: "Laboratorio Técnico | Arkeonix Labs" },
+  { name: "description", content: "Guías avanzadas de equipos, servidores y despliegue técnico por Arkeonix Labs." },
+  { tagName: "link", rel: "canonical", href: "https://arkeonixlabs.com/lab" },
+  { property: "og:title", content: "Laboratorio Técnico | Arkeonix Labs" },
+  { property: "og:description", content: "Guías avanzadas de equipos, servidores y despliegue técnico por Arkeonix Labs." },
+  { property: "og:image", content: "https://arkeonixlabs.com/arkeonix-logo.png" },
+  { property: "og:url", content: "https://arkeonixlabs.com/lab" },
+  { name: "twitter:card", content: "summary_large_image" },
+  { name: "twitter:title", content: "Laboratorio Técnico | Arkeonix Labs" },
+  { name: "twitter:description", content: "Guías avanzadas de equipos, servidores y despliegue técnico por Arkeonix Labs." },
+  { name: "twitter:image", content: "https://arkeonixlabs.com/arkeonix-logo.png" },
+];
 import { FiTerminal } from "react-icons/fi";
 import LabPostCard from "@/components/posts/LabPostCard";
 import Pagination from "@/components/ui/Pagination";

--- a/src/pages/LabPostPage.tsx
+++ b/src/pages/LabPostPage.tsx
@@ -12,8 +12,50 @@ import ScrollReveal from "@/components/ui/ScrollReveal";
 import ShareButtons from "@/components/ui/ShareButtons";
 import Breadcrumbs from "@/components/ui/Breadcrumbs";
 import type { LabPostDetail } from "@/types/lab";
+import type { LoaderFunctionArgs, MetaFunction } from "react-router";
 
 marked.setOptions({ async: false });
+
+// eslint-disable-next-line react-refresh/only-export-components
+export async function loader({ params }: LoaderFunctionArgs) {
+    if (!params.slug) return { post: null };
+    const { data } = await supabase
+        .from("lab_posts")
+        .select("title, cover_image, tags, difficulty")
+        .eq("slug", params.slug)
+        .eq("status", "published")
+        .maybeSingle();
+    return { post: (data as Pick<LabPostDetail, "title" | "cover_image" | "tags" | "difficulty"> | null) };
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const meta: MetaFunction<typeof loader> = ({ data, params }) => {
+    const post = data?.post;
+    const slug = params.slug ?? "";
+    const url = `https://arkeonixlabs.com/lab/${slug}`;
+    if (!post) {
+        return [
+            { title: "Reporte no encontrado | Arkeonix Labs" },
+            { name: "robots", content: "noindex, follow" },
+        ];
+    }
+    const image = post.cover_image
+        ? post.cover_image
+        : `https://arkeonixlabs.com/api/og?title=${encodeURIComponent(post.title)}&category=Lab&author=Arkeonix Labs`;
+    return [
+        { title: `${post.title} | Laboratorio — Arkeonix Labs` },
+        { name: "description", content: `Guía técnica: ${post.title}. Arkeonix Labs.` },
+        { tagName: "link", rel: "canonical", href: url },
+        { property: "og:title", content: `${post.title} | Laboratorio — Arkeonix Labs` },
+        { property: "og:description", content: `Guía técnica: ${post.title}. Arkeonix Labs.` },
+        { property: "og:type", content: "article" },
+        { property: "og:image", content: image },
+        { property: "og:url", content: url },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:title", content: `${post.title} | Laboratorio — Arkeonix Labs` },
+        { name: "twitter:image", content: image },
+    ];
+};
 
 const DIFFICULTY_STYLES: Record<string, string> = {
     beginner: "bg-emerald-500/15 text-emerald-400 border-emerald-500/30",

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,7 +1,19 @@
-import { Link } from "react-router";
+import { Link, data } from "react-router";
 import { Helmet } from "react-helmet-async";
 import { FiHome, FiArrowLeft, FiAlertTriangle } from "react-icons/fi";
 import { useLocale } from "@/hooks/useLocale";
+import type { MetaFunction } from "react-router";
+
+// eslint-disable-next-line react-refresh/only-export-components
+export async function loader() {
+  return data(null, { status: 404 });
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const meta: MetaFunction = () => [
+  { title: "404 — Página no encontrada | Arkeonix Labs" },
+  { name: "robots", content: "noindex, follow" },
+];
 
 export default function NotFoundPage() {
   const { t } = useLocale();

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -14,7 +14,35 @@ import TableOfContents from "@/components/ui/TableOfContents";
 import SmartImage from "@/components/ui/SmartImage";
 import type { PostDetail } from "@/types/post";
 import { useLoaderData } from "react-router";
-import type { LoaderFunctionArgs } from "react-router";
+import type { LoaderFunctionArgs, MetaFunction } from "react-router";
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const meta: MetaFunction<typeof loader> = ({ data, params }) => {
+  const post = data?.post;
+  const slug = params.slug ?? "";
+  const url = `https://arkeonixlabs.com/post/${slug}`;
+  if (!post) {
+    return [
+      { title: "Post no encontrado | Arkeonix Labs" },
+      { name: "robots", content: "noindex, follow" },
+    ];
+  }
+  const image = post.cover_image
+    ? post.cover_image
+    : `https://arkeonixlabs.com/api/og?title=${encodeURIComponent(post.title)}&category=${encodeURIComponent(post.category ?? "")}&author=${encodeURIComponent(post.author)}`;
+  return [
+    { title: `${post.title} | Arkeonix Labs` },
+    { tagName: "link", rel: "canonical", href: url },
+    { property: "og:title", content: `${post.title} | Arkeonix Labs` },
+    { property: "og:description", content: post.title },
+    { property: "og:type", content: "article" },
+    { property: "og:image", content: image },
+    { property: "og:url", content: url },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:title", content: `${post.title} | Arkeonix Labs` },
+    { name: "twitter:image", content: image },
+  ];
+};
 
 const RECURSOS_CATEGORY_VALUES = [
   "product",

--- a/src/pages/PrivacyPolicyPage.tsx
+++ b/src/pages/PrivacyPolicyPage.tsx
@@ -1,4 +1,13 @@
 import { Helmet } from "react-helmet-async";
+import type { MetaFunction } from "react-router";
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const meta: MetaFunction = () => [
+  { title: "Política de Privacidad | Arkeonix Labs" },
+  { name: "description", content: "En Arkeonix Labs, la privacidad es una extensión de nuestra seguridad técnica. Detallamos cómo protegemos tu información." },
+  { tagName: "link", rel: "canonical", href: "https://arkeonixlabs.com/privacy" },
+  { name: "robots", content: "noindex, follow" },
+];
 import { useLocale } from "@/hooks/useLocale";
 import ScrollReveal from "@/components/ui/ScrollReveal";
 

--- a/src/pages/RecursosPage.tsx
+++ b/src/pages/RecursosPage.tsx
@@ -1,5 +1,21 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { Helmet } from "react-helmet-async";
+import type { MetaFunction } from "react-router";
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const meta: MetaFunction = () => [
+  { title: "Recursos Seleccionados | Arkeonix Labs" },
+  { name: "description", content: "Recomendaciones expertas y análisis técnicos de herramientas, hardware y software por Arkeonix Labs." },
+  { tagName: "link", rel: "canonical", href: "https://arkeonixlabs.com/recursos" },
+  { property: "og:title", content: "Recursos Seleccionados | Arkeonix Labs" },
+  { property: "og:description", content: "Recomendaciones expertas y análisis técnicos de herramientas, hardware y software por Arkeonix Labs." },
+  { property: "og:image", content: "https://arkeonixlabs.com/arkeonix-logo.png" },
+  { property: "og:url", content: "https://arkeonixlabs.com/recursos" },
+  { name: "twitter:card", content: "summary_large_image" },
+  { name: "twitter:title", content: "Recursos Seleccionados | Arkeonix Labs" },
+  { name: "twitter:description", content: "Recomendaciones expertas y análisis técnicos de herramientas, hardware y software por Arkeonix Labs." },
+  { name: "twitter:image", content: "https://arkeonixlabs.com/arkeonix-logo.png" },
+];
 import {
   FiFilter, FiChevronDown, FiSearch, FiExternalLink,
 } from "react-icons/fi";

--- a/src/pages/TermsPage.tsx
+++ b/src/pages/TermsPage.tsx
@@ -1,4 +1,13 @@
 import { Helmet } from "react-helmet-async";
+import type { MetaFunction } from "react-router";
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const meta: MetaFunction = () => [
+  { title: "Términos de Uso | Arkeonix Labs" },
+  { name: "description", content: "El uso de Arkeonix Labs implica la aceptación de nuestras normas de navegación y uso de contenido técnico." },
+  { tagName: "link", rel: "canonical", href: "https://arkeonixlabs.com/terms" },
+  { name: "robots", content: "noindex, follow" },
+];
 import { useLocale } from "@/hooks/useLocale";
 import ScrollReveal from "@/components/ui/ScrollReveal";
 

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -21,7 +21,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        
+
         {/* Google Tag Manager */}
         <script dangerouslySetInnerHTML={{ __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -32,17 +32,64 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Meta />
         <Links />
 
-        {/* Global meta tags that act as fallback */}
+        {/* Fallback meta tags — overridden by each route's meta export */}
+        <title>Arkeonix Labs — Precisión Técnica</title>
+        <meta name="description" content="Análisis técnicos detallados y vanguardia tecnológica bajo el estándar de Arkeonix Labs." />
+        <meta name="author" content="David López" />
+        <meta name="robots" content="index, follow" />
+        <link rel="canonical" href="https://arkeonixlabs.com/" />
+
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://www.arkeonixlabs.com/" />
+        <meta property="og:url" content="https://arkeonixlabs.com/" />
         <meta property="og:site_name" content="Arkeonix Labs" />
+        <meta property="og:title" content="Arkeonix Labs — Precisión Técnica" />
+        <meta property="og:description" content="Análisis técnicos detallados y vanguardia tecnológica bajo el estándar de Arkeonix Labs." />
+        <meta property="og:image" content="https://arkeonixlabs.com/arkeonix-logo.png" />
         <meta property="og:locale" content="es_ES" />
         <meta property="og:locale:alternate" content="en_US" />
-        
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Arkeonix Labs — Precisión Técnica" />
+        <meta name="twitter:description" content="Análisis técnicos detallados y vanguardia tecnológica bajo el estándar de Arkeonix Labs." />
+        <meta name="twitter:image" content="https://arkeonixlabs.com/arkeonix-logo.png" />
+
+        {/* JSON-LD: Organization + WebSite */}
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "Organization",
+          "name": "Arkeonix Labs",
+          "url": "https://arkeonixlabs.com",
+          "logo": "https://arkeonixlabs.com/arkeonix-logo.png",
+          "description": "Análisis técnicos detallados y vanguardia tecnológica bajo el estándar de Arkeonix Labs.",
+          "sameAs": [
+            "https://github.com/ArkeonProject",
+            "https://www.linkedin.com/in/david-l%C3%B3pez-santamar%C3%ADa-946965260/"
+          ],
+          "contactPoint": {
+            "@type": "ContactPoint",
+            "contactType": "customer service",
+            "url": "https://arkeonixlabs.com/contact"
+          }
+        })}} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "WebSite",
+          "name": "Arkeonix Labs",
+          "url": "https://arkeonixlabs.com",
+          "description": "Análisis técnicos detallados y vanguardia tecnológica bajo el estándar de Arkeonix Labs.",
+          "inLanguage": ["es", "en"],
+          "potentialAction": {
+            "@type": "SearchAction",
+            "target": "https://arkeonixlabs.com/blog?q={search_term_string}",
+            "query-input": "required name=search_term_string"
+          }
+        })}} />
+
         <meta name="theme-color" content="#00aaff" />
         <link rel="icon" type="image/png" href="/arkeonix-logo.png" />
         <link rel="apple-touch-icon" href="/arkeonix-logo.png" />
         <link rel="manifest" href="/manifest.json" />
+        <link rel="me" href="https://github.com/ArkeonProject" />
 
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
@@ -77,8 +124,16 @@ function GlobalLayout() {
 
   return (
     <div className="flex flex-col min-h-screen bg-background text-foreground transition-colors duration-300">
-      <Header />
-      <main className="grow container mx-auto px-4 pt-24 pb-12">
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-100 focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-lg focus:font-semibold focus:text-sm"
+      >
+        {t("a11y_skip_link")}
+      </a>
+      <header>
+        <Header />
+      </header>
+      <main id="main" className="grow container mx-auto px-4 pt-24 pb-12">
         <Outlet />
       </main>
       <Footer />

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,12 @@
 {
   "redirects": [
     {
+      "source": "/(.*)",
+      "has": [{ "type": "host", "value": "www.arkeonixlabs.com" }],
+      "destination": "https://arkeonixlabs.com/$1",
+      "permanent": true
+    },
+    {
       "source": "/news",
       "destination": "/blog",
       "permanent": true
@@ -23,7 +29,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://*.google-analytics.com https://*.analytics.google.com; frame-src 'self' https://www.youtube.com;"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://*.google-analytics.com https://*.analytics.google.com; frame-src 'self' https://www.youtube.com; frame-ancestors 'none';"
         },
         {
           "key": "X-Frame-Options",
@@ -40,6 +46,10 @@
         {
           "key": "Permissions-Policy",
           "value": "camera=(), microphone=(), geolocation=()"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- **Meta tags en prerendering**: añadidos `meta` exports de React Router v7 en todas las páginas para que title, description, OG y Twitter cards estén en el HTML estático (visible para crawlers sin JS)
- **www → non-www redirect** (301) en `vercel.json`
- **HTTP 404 real** para rutas desconocidas via `data(null, { status: 404 })`
- **Seguridad**: HSTS con `includeSubDomains; preload`, CSP con `frame-ancestors 'none'`
- **Accesibilidad**: skip link traducido (`a11y_skip_link`), `<header>` landmark, `id="main"`
- **Performance**: `width`/`height` en logos del Header y Footer (elimina CLS)
- **GitHub link roto** corregido en Footer (`ArkeonixLabs` → `ArkeonProject`)
- **`/llms.txt`** creado para AI/GEO discoverability
- **Precio Guía Junior** actualizado a 19€ pago único en capítulo gratuito

## Test plan

- [ ] Verificar que el HTML prerendered incluye `<title>` y meta tags (curl o View Source)
- [ ] Confirmar redirect 301 de `www.arkeonixlabs.com` → `arkeonixlabs.com`
- [ ] Comprobar que rutas inexistentes devuelven HTTP 404
- [ ] Verificar headers HSTS y CSP en respuesta del servidor
- [ ] Revisar precio 19€ visible en `/guia-junior/capitulo/chapter-0`
- [ ] Skip link visible al tabular desde teclado

🤖 Generated with [Claude Code](https://claude.com/claude-code)