### PR TITLE
fix(ci): añadir packageManager pnpm@9

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "2.12.1",
   "type": "module",
+  "packageManager": "pnpm@9",
   "scripts": {
     "dev": "react-router dev",
     "dev:full": "vercel dev --token $VERCEL_TOKEN --scope daviilpzdevs-projects",


### PR DESCRIPTION
## Fix

`pnpm/action-setup@v4` requiere que la versión de pnpm esté especificada via `"version"` en el action o `"packageManager"` en `package.json`. Sin este campo el CI falla con:

```
Error: No pnpm version is specified.
```

## Cambio

Añade `"packageManager": "pnpm@9"` en `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)