### PR TITLE
fix(vercel): eliminar redirect www→non-www — loop infinito

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,6 @@
 {
   "redirects": [
     {
-      "source": "/(.*)",
-      "has": [{ "type": "host", "value": "www.arkeonixlabs.com" }],
-      "destination": "https://arkeonixlabs.com/$1",
-      "permanent": true
-    },
-    {
       "source": "/news",
       "destination": "/blog",
       "permanent": true


### PR DESCRIPTION
El redirect www→non-www en vercel.json choca con el redirect inverso del dashboard de Vercel, dejando el sitio inaccesible. Se elimina el redirect del código.