### PR TITLE
ci: migrate workflows to organization-tools@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: CI
 
 on:
   push:
-    branches: [develop, main]
+    branches: [main, 'feature/**']
   pull_request:
-    branches: [develop, main]
+    branches: [main]
 
 jobs:
   ci:
     name: Continuous Integration
-    uses: ArkeonProject/organization-tools/.github/workflows/ci-node.yml@v1.1.5
+    uses: ArkeonProject/organization-tools/.github/workflows/ci-node.yml@v1
     with:
       node-version: '20'
       package-manager: 'pnpm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main, 'feature/**']
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,34 +9,14 @@ on:
 jobs:
   ci:
     name: Continuous Integration
-    runs-on: [self-hosted, n100]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Lint
-        run: pnpm lint
-
-      - name: Typecheck
-        run: pnpm typecheck
-
-      - name: Build
-        run: pnpm build
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build
-          path: dist
+    uses: ArkeonProject/organization-tools/.github/workflows/ci-node.yml@v1
+    with:
+      node-version: '20'
+      package-manager: 'pnpm'
+      run-lint: true
+      run-typecheck: true
+      run-tests: false
+      run-build: true
+      upload-coverage: false
+      upload-artifacts: true
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,34 @@ on:
 jobs:
   ci:
     name: Continuous Integration
-    uses: ArkeonProject/organization-tools/.github/workflows/ci-node.yml@v1
-    with:
-      node-version: '20'
-      package-manager: 'pnpm'
-      run-lint: true
-      run-typecheck: true
-      run-tests: false
-      run-build: true
-      upload-coverage: false
-      upload-artifacts: true
-    secrets: inherit
+    runs-on: [self-hosted, n100]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,15 @@
 name: CI
 
 on:
+  push:
+    branches: [main, 'feature/**']
   pull_request:
     branches: [main]
 
 jobs:
   ci:
     name: Continuous Integration
-    uses: ArkeonProject/organization-tools/.github/workflows/ci-node.yml@v1
+    uses: ArkeonProject/organization-tools/.github/workflows/ci-node-selfhosted.yml@v1
     with:
       node-version: '20'
       package-manager: 'pnpm'

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -4,18 +4,19 @@ on:
   workflow_dispatch:
     inputs:
       description:
-        description: 'Hotfix description'
+        description: 'Hotfix description (e.g. fix-auth-token-expiry)'
         required: true
         type: string
       issue-number:
-        description: 'Issue number (optional)'
+        description: 'Related issue number (optional)'
         required: false
-        type: number
+        type: string
 
 jobs:
   create-hotfix:
     name: Create Hotfix
-    uses: ArkeonProject/organization-tools/.github/workflows/hotfix-create.yml@v1.1.5
+    uses: ArkeonProject/organization-tools/.github/workflows/hotfix-create.yml@v1
     with:
       description: ${{ github.event.inputs.description }}
       issue-number: ${{ github.event.inputs.issue-number }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,33 +1,13 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      version-bump:
-        description: 'Version bump type'
-        required: true
-        default: 'patch'
-        type: choice
-        options:
-          - major
-          - minor
-          - patch
   push:
     branches: [main]
 
 jobs:
-  prepare-release:
-    name: Prepare Release
-    if: github.event_name == 'workflow_dispatch'
-    uses: ArkeonProject/organization-tools/.github/workflows/release-prepare.yml@v1.1.5
-    with:
-      version-bump: ${{ github.event.inputs.version-bump }}
-      project-type: 'node'
-
-  publish-release:
+  publish:
     name: Publish Release
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    uses: ArkeonProject/organization-tools/.github/workflows/release-publish.yml@v1.1.5
+    uses: ArkeonProject/organization-tools/.github/workflows/release-publish.yml@v1
     with:
-      project-type: 'node'
       create-github-release: true
+    secrets: inherit


### PR DESCRIPTION
## Summary

Migración a Trunk-Based Development con workflows centralizados de `organization-tools@v1`.

### Antes
- `ci.yml`: inline self-hosted runner (referencia indirecta a organization-tools@v1.1.5 previa)
- `release.yml`: @v1.1.5 con workflow_dispatch manual para prepare-release
- `hotfix.yml`: @v1.1.5
- Triggers de CI apuntaban a `main` y `develop`

### Cambios
- `ci.yml`: ahora usa el reusable workflow `ci-node.yml@v1` con inputs configurados:
  - node-version: `20`
  - package-manager: `pnpm`
  - run-lint: `true`
  - run-typecheck: `true`
  - run-tests: `false` (el repo no tiene tests)
  - run-build: `true`
  - upload-artifacts: `true`
- `release.yml`: simplificado a `release-publish.yml@v1` con release automático por Conventional Commits
- `hotfix.yml`: actualizado a `hotfix-create.yml@v1`
- Eliminadas todas las referencias a `develop` en triggers de CI
- `cd.yml`: se dejó intacto (apunta a @v1.1.6)

### Notas
- Hay **4 commits en `origin/develop`** que aún no están en `main`. Revisar antes de mergear este PR:
  - `e4310e0` chore(ci): añadir vercel.json al paths trigger del CD
  - `891ec5f` fix(vercel): eliminar redirect www→non-www para evitar loop
  - `c74e97f` fix(ci): añadir packageManager pnpm@9 para pnpm/action-setup@v4
  - `001838d` chore: back-merge v2.12.1

### ⚠️ Atención
El `ci.yml` anterior usaba `runs-on: [self-hosted, n100]` por un problema conocido con `pnpm/action-setup@v6` y dependencias de npm en runners self-hosted. Al migrar al reusable workflow de `organization-tools@v1`, el runner será el definido por el template centralizado (probablemente `ubuntu-latest`). Verificar compatibilidad antes de mergear.