### PR TITLE
fix: homepage Labs link points to / and ecosystem cards are active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 
 ### Fixed
 
+- El link "Arkeonix Labs" del header ahora apunta a la homepage (`/`) en lugar de `/blog`.
+- Las cards "Herramientas" y "Rutas" en la homepage ya no aparecen como "Próximamente" y son navegables.
 - Contenido de post centrado correctamente cuando no hay tabla de contenidos lateral.
 - Título de página Arkeonix acortado para evitar truncamiento en SERPs.
 - Portfolio checklist: corregidos `aria-label` en controles de formulario y añadidos tests.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -170,7 +170,7 @@ export default function Header() {
             }`}
         >
           {/* Logo */}
-          <Link to="/blog" className="flex-shrink-0 flex items-center gap-2.5 group min-w-0">
+          <Link to="/" className="flex-shrink-0 flex items-center gap-2.5 group min-w-0">
             <img
               src="/arkeonix-logo.png"
               alt="Arkeonix Labs Logo"

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -133,7 +133,7 @@ export default function HomePage() {
       titleKey: "home_ecosystem_tools_title",
       descKey: "home_ecosystem_tools_desc",
       link: "/herramientas",
-      comingSoon: true,
+      comingSoon: false,
     },
     {
       key: "routes",
@@ -143,7 +143,7 @@ export default function HomePage() {
       titleKey: "home_ecosystem_routes_title",
       descKey: "home_ecosystem_routes_desc",
       link: "/rutas",
-      comingSoon: true,
+      comingSoon: false,
     },
     {
       key: "lab",


### PR DESCRIPTION
### Why

- The "Arkeonix Labs" brand link in the header was navigating to `/blog` instead of the homepage (`/`).
- The "Herramientas" and "Rutas" ecosystem cards were displayed as disabled ("Próximamente") despite the features being already built and functional.

### What

1. **Header.tsx:173** — Changed brand link `to="/blog"` → `to="/"`
2. **HomePage.tsx:136,146** — Set `comingSoon: false` for both tools and routes cards
3. **CHANGELOG.md** — Added entries under `[Unreleased] > Fixed`